### PR TITLE
resolve lb9 reboot Oops

### DIFF
--- a/3.2.65-1+deb7u2/patches/platform-powerpc-quanta-lb9-r0.patch
+++ b/3.2.65-1+deb7u2/patches/platform-powerpc-quanta-lb9-r0.patch
@@ -1,7 +1,7 @@
 diff -rupN a/arch/powerpc/boot/dts/powerpc-quanta-lb9-r0.dts b/arch/powerpc/boot/dts/powerpc-quanta-lb9-r0.dts
 --- a/arch/powerpc/boot/dts/powerpc-quanta-lb9-r0.dts	1969-12-31 16:00:00.000000000 -0800
-+++ b/arch/powerpc/boot/dts/powerpc-quanta-lb9-r0.dts	2015-05-20 18:02:37.214080791 -0700
-@@ -0,0 +1,480 @@
++++ b/arch/powerpc/boot/dts/powerpc-quanta-lb9-r0.dts	2015-06-02 12:53:56.475579023 -0700
+@@ -0,0 +1,509 @@
 +/*
 + * <bsn.cl fy=2013 v=gpl>
 + * 
@@ -26,6 +26,7 @@ diff -rupN a/arch/powerpc/boot/dts/powerpc-quanta-lb9-r0.dts b/arch/powerpc/boot
 +/ {
 +	model = "powerpc-quanta-lb9-r0";
 +	compatible = "quanta,lb9";
++	reset-gpio = <&cpm_pio_a 24 1>;
 +	#address-cells = <1>;
 +	#size-cells = <1>;
 +
@@ -359,40 +360,68 @@ diff -rupN a/arch/powerpc/boot/dts/powerpc-quanta-lb9-r0.dts b/arch/powerpc/boot
 +			reg = <0x919c0 0x30>;
 +			ranges;
 +
-+			gpio0: cpm-pario-a@10d00 {
-+				#gpio-cells = <2>;
-+				compatible = "fsl,cpm2-pario-bank";
-+				reg = <0x90d00 0x14>;
-+				gpio-controller;
++			muram@80000 {
++				#address-cells = <1>;
++				#size-cells = <1>;
++				ranges = <0x0 0x80000 0x10000>;
++
++				data@0 {
++					compatible = "fsl,cpm-muram-data";
++					reg = <0x0 0x2000 0x9000 0x1000>;
++				};
 +			};
 +
-+			cpm-pario-b@90d20 {
-+				#gpio-cells = <2>;
-+				compatible = "fsl,cpm2-pario-bank";
-+				reg = <0x90d20 0x14>;
-+				gpio-controller;
++			brg@919f0 {
++				compatible = "fsl,mpc8541-brg",
++						"fsl,cpm2-brg",
++						"fsl,cpm-brg";
++				reg = <0x919f0 0x10 0x915f0 0x10>;
 +			};
 +
-+			cpm-pario-c@90d40 {
-+				#gpio-cells = <2>;
-+				compatible = "fsl,cpm2-pario-bank";
-+				reg = <0x90d40 0x14>;
-+				gpio-controller;
++			cpmpic: pic@90c00 {
++				interrupt-controller;
++				#address-cells = <0>;
++				#interrupt-cells = <2>;
++				interrupts = <46 2>;
++				interrupt-parent = <&mpic>;
++				reg = <0x90c00 0x80>;
++				compatible = "fsl,mpc8541-cpm-pic", "fsl,cpm2-pic";
 +			};
++		};
 +
-+			cpm-pario-d@90d60 {
-+				#gpio-cells = <2>;
-+				compatible = "fsl,cpm2-pario-bank";
-+				reg = <0x90d60 0x14>;
-+				gpio-controller;
-+			};
++		cpm_pio_a: gpio-controller@90d00 {
++			#gpio-cells = <2>;
++			compatible = "fsl,cpm2-pario-bank";
++			reg = <0x90d00 0x14>;
++			gpio-controller;
++		};
++
++		cpm_pio_b: gpio-controller@90d20 {
++			#gpio-cells = <2>;
++			compatible = "fsl,cpm2-pario-bank";
++			reg = <0x90d20 0x14>;
++			gpio-controller;
++		};
++
++		cpm_pio_c: gpio-controller@90d40 {
++			#gpio-cells = <2>;
++			compatible = "fsl,cpm2-pario-bank";
++			reg = <0x90d40 0x14>;
++			gpio-controller;
++		};
++
++		cpm_pio_d: gpio-controller@90d60 {
++			#gpio-cells = <2>;
++			compatible = "fsl,cpm2-pario-bank";
++			reg = <0x90d60 0x14>;
++			gpio-controller;
 +		};
 +	};
 +
 +	leds {
 +		compatible = "gpio-leds";
 +		system-status {
-+			gpios = <&gpio0 22 1>;
++			gpios = <&cpm_pio_a 22 1>;
 +			linux,default-trigger = "default-on";
 +		};
 +	};


### PR DESCRIPTION
Reviewer: @jnealtowns 

Jeff, could you take a look at original gpio0 address definition? Why is it 0x10d00 instead of 0x90d00? My modification actually changes it to 0x90d00(with different name), don't know if it will break anything(led, e.g.)

Thanks

Zi
